### PR TITLE
Prevent UI full screen on startup

### DIFF
--- a/hooks/admin_img.html
+++ b/hooks/admin_img.html
@@ -1,1 +1,1 @@
-<a href="/CMD_PLUGINS_ADMIN/rspamd/index.raw" target="_top"><img src="/CMD_PLUGINS_ADMIN/rspamd/images/logo.png">Rspamd<br></a>
+<a href="/CMD_PLUGINS_ADMIN/rspamd/" target="_top"><img src="/CMD_PLUGINS_ADMIN/rspamd/images/logo.png">Rspamd<br></a>

--- a/hooks/admin_txt.html
+++ b/hooks/admin_txt.html
@@ -1,1 +1,1 @@
-<a href="/CMD_PLUGINS_ADMIN/rspamd/index.raw" target="_top">Rspamd Web Interface</a>
+<a href="/CMD_PLUGINS_ADMIN/rspamd/" target="_top">Rspamd Web Interface</a>


### PR DESCRIPTION
It would fit the entires screen on startup.
There will be problem using the Evolution Skin with Hybrid or Grid option. You won't see the maximize or minimize button to quit the UI and the main directadmin header UI is not visible.

As mentioned: https://forum.directadmin.com/showthread.php?t=57856&p=300807#post300807